### PR TITLE
Updates to fix missing NetCDF Fortran includes

### DIFF
--- a/GMAO_gfio/CMakeLists.txt
+++ b/GMAO_gfio/CMakeLists.txt
@@ -48,6 +48,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories (${BASEDIR}/lib)
 include_directories (${include_${this}})
 include_directories (${INC_NETCDF})
+include_directories (${NETCDF_F77_INCLUDE_DIR})
 
 if (F2PY_FOUND)
    if (precision STREQUAL "r4")


### PR DESCRIPTION
This commit will allow compatibility with MAPL 2.5.0, and is one of several PRs being performed with that in mind.